### PR TITLE
Add music dashboard example

### DIFF
--- a/music-dashboard/.eslintrc.json
+++ b/music-dashboard/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "env": { "node": true, "es2020": true },
+  "extends": "eslint:recommended",
+  "parserOptions": { "ecmaVersion": 2020, "sourceType": "module" },
+  "rules": {}
+}

--- a/music-dashboard/README.md
+++ b/music-dashboard/README.md
@@ -1,0 +1,14 @@
+# Music Dashboard
+
+A simple Express application that visualizes global music sales and lets you search for new music via the iTunes API.
+
+## Setup
+
+```bash
+pnpm install
+pnpm start
+```
+
+The server will fetch sales data from [this dataset](https://github.com/rufuspollock/music-sales) and expose it at `/api/sales`. It also proxies search queries to the iTunes Search API.
+
+Open `http://localhost:3000` in your browser to view the dashboard.

--- a/music-dashboard/index.js
+++ b/music-dashboard/index.js
@@ -1,0 +1,44 @@
+import express from "express";
+import fetch from "node-fetch";
+import { parse } from "csv-parse/sync";
+
+const SALES_URL =
+  "https://raw.githubusercontent.com/rufuspollock/music-sales/master/data/data.csv";
+
+async function fetchSales() {
+  const res = await fetch(SALES_URL);
+  const text = await res.text();
+  const records = parse(text, {
+    columns: true,
+    skip_empty_lines: true,
+  });
+  return records;
+}
+
+const app = express();
+let salesData = [];
+
+app.use(express.static("public"));
+
+app.get("/api/sales", async (req, res) => {
+  if (salesData.length === 0) {
+    salesData = await fetchSales();
+  }
+  res.json(salesData);
+});
+
+app.get("/api/search", async (req, res) => {
+  const term = req.query.term;
+  if (!term) {
+    return res.status(400).json({ error: "term query required" });
+  }
+  const searchUrl = `https://itunes.apple.com/search?term=${encodeURIComponent(term)}&limit=10`;
+  const response = await fetch(searchUrl);
+  const json = await response.json();
+  res.json(json);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () =>
+  console.log(`Music dashboard running on http://localhost:${PORT}`),
+);

--- a/music-dashboard/package.json
+++ b/music-dashboard/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "music-dashboard",
+  "version": "1.0.0",
+  "description": "Demo dashboard for music sales and discovery",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^5.1.0",
+    "node-fetch": "^3.3.2",
+    "csv-parse": "^5.5.4"
+  }
+}

--- a/music-dashboard/public/index.html
+++ b/music-dashboard/public/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Music Sales Dashboard</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 40px;
+      }
+      canvas {
+        max-width: 800px;
+      }
+      #results img {
+        width: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Music Sales Dashboard</h1>
+    <canvas id="chart"></canvas>
+
+    <h2>Find Music</h2>
+    <input id="search" placeholder="Search artists or albums" />
+    <button onclick="search()">Search</button>
+    <div id="results"></div>
+
+    <script>
+      async function loadSales() {
+        const res = await fetch("/api/sales");
+        const data = await res.json();
+        const years = data.map((d) => d.Year);
+        const totals = data.map((d) => Number(d["Sales (Nominal)"]));
+        new Chart(document.getElementById("chart"), {
+          type: "line",
+          data: {
+            labels: years,
+            datasets: [
+              {
+                label: "Global Sales",
+                data: totals,
+                borderColor: "blue",
+                fill: false,
+              },
+            ],
+          },
+        });
+      }
+
+      async function search() {
+        const term = document.getElementById("search").value;
+        const res = await fetch("/api/search?term=" + encodeURIComponent(term));
+        const data = await res.json();
+        const container = document.getElementById("results");
+        container.innerHTML = data.results
+          .map(
+            (r) =>
+              `<div><img src="${r.artworkUrl100}"/><p>${r.collectionName}</p></div>`,
+          )
+          .join("");
+      }
+
+      loadSales();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- provide a `music-dashboard` demo app
- fetch global music sales CSV from GitHub
- expose a search endpoint that proxies to the iTunes API
- simple HTML dashboard using Chart.js for visualization

## Testing
- `pnpm test`
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_686603b8a43483299d8dc832cacc125b